### PR TITLE
Introduces the ability to produce to the commit log

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -111,6 +111,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "chrono"
+version = "0.4.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
+dependencies = [
+ "libc",
+ "num-integer",
+ "num-traits",
+ "serde",
+ "time",
+ "winapi",
+]
+
+[[package]]
 name = "cipher"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -311,7 +325,7 @@ checksum = "4eb1a864a501629691edf6c15a593b7a51eebaa1e8468e9ddc623de7c9b58ec6"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -588,7 +602,7 @@ checksum = "57ee1c23c7c63b0c9250c339ffdc69255f110b298b901b9f6c82547b7b87caaf"
 dependencies = [
  "libc",
  "log",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys",
 ]
 
@@ -608,6 +622,25 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "tempfile",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
+dependencies = [
+ "autocfg",
+ "num-traits",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]
@@ -964,6 +997,7 @@ dependencies = [
  "async-trait",
  "base64",
  "cache_loader_async",
+ "chrono",
  "hex",
  "http",
  "humantime",
@@ -1021,6 +1055,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "time"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
+dependencies = [
+ "libc",
+ "wasi 0.10.0+wasi-snapshot-preview1",
+ "winapi",
 ]
 
 [[package]]
@@ -1197,6 +1242,12 @@ dependencies = [
  "log",
  "try-lock",
 ]
+
+[[package]]
+name = "wasi"
+version = "0.10.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wasi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ async-stream = "0.3"
 async-trait = "0.1"
 base64 = "0.13"
 cache_loader_async = { version = "0.2.0", features = ["lru-cache", "ttl-cache"] }
+chrono = { version = "0.4", features = ["serde"] }
 hex = "0.4"
 humantime = "2.1"
 log = "0.4"

--- a/src/commit_log.rs
+++ b/src/commit_log.rs
@@ -1,9 +1,12 @@
-/// Commit log functionality that is modelled on Apache Kafka's
-/// API, but can be implemented with multiple types of backend
-/// e.g. one that uses the Kafka HTTP REST API.
+//! Commit log functionality that is modelled on Apache Kafka's
+//! API, but can be implemented with multiple types of backend
+//! e.g. one that uses the Kafka HTTP REST API.
+
 use std::{pin::Pin, time::Duration};
 
 use super::base64_serde;
+use async_trait::async_trait;
+use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use tokio_stream::Stream;
 
@@ -12,6 +15,15 @@ use tokio_stream::Stream;
 /// a `:`. For example, "my-ns:my-topic". In the absence of
 /// a namespace, the server will assume a default namespace.
 pub type Topic = String;
+
+/// A header provides a means of augmenting a record with
+/// meta-data.
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+pub struct Header {
+    key: String,
+    #[serde(with = "base64_serde")]
+    value: Vec<u8>,
+}
 
 /// A declaration of an offset to be committed to a topic.
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
@@ -40,10 +52,12 @@ pub struct Consumer {
     pub subscriptions: Option<Vec<Subscription>>,
 }
 
-/// A declaration of a record produced by a subscription.
+/// A declaration of a record produced by a subscription
 #[derive(Clone, Deserialize, Debug, PartialEq, Serialize)]
-pub struct Record {
+pub struct ConsumerRecord {
     pub topic: Topic,
+    pub headers: Vec<Header>,
+    pub timestamp: Option<DateTime<Utc>>,
     pub key: u64,
     #[serde(with = "base64_serde")]
     pub value: Vec<u8>,
@@ -51,7 +65,35 @@ pub struct Record {
     pub offset: u64,
 }
 
+/// A declaration of a record produced by a subscription
+#[derive(Clone, Deserialize, Debug, PartialEq, Serialize)]
+pub struct ProducerRecord {
+    pub topic: Topic,
+    pub headers: Vec<Header>,
+    pub timestamp: Option<DateTime<Utc>>,
+    pub key: u64,
+    #[serde(with = "base64_serde")]
+    pub value: Vec<u8>,
+    pub partition: u32,
+}
+
+/// The reply to a publish request
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+pub struct ProducedOffset {
+    pub offset: u64,
+}
+
+/// There was a problem producing a record
+#[derive(Clone, Debug, PartialEq)]
+pub enum ProducerError {
+    /// The commit log received the request but was unable to process it.
+    CannotProduce,
+    /// The commit log is unavailable at this time. Try later.
+    Unavailable,
+}
+
 /// A commit log holds topics and can be appended to and tailed.
+#[async_trait]
 pub trait CommitLog {
     /// Subscribe to one or more topics for a given consumer group
     /// having committed zero or more topics. Connections are
@@ -71,5 +113,8 @@ pub trait CommitLog {
         offsets: Option<&[Offset]>,
         subscriptions: Option<&[Subscription]>,
         idle_timeout: Option<Duration>,
-    ) -> Pin<Box<dyn Stream<Item = Record> + 'a>>;
+    ) -> Pin<Box<dyn Stream<Item = ConsumerRecord> + 'a>>;
+
+    /// Publish a record and return the offset that was assigned.
+    async fn produce(&self, record: &ProducerRecord) -> Result<ProducedOffset, ProducerError>;
 }

--- a/src/commit_log.rs
+++ b/src/commit_log.rs
@@ -27,7 +27,7 @@ pub struct Header {
 
 /// A declaration of an offset to be committed to a topic.
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
-pub struct Offset {
+pub struct ConsumerOffset {
     pub topic: Topic,
     pub partition: u32,
     pub offset: u64,
@@ -48,7 +48,7 @@ pub struct Subscription {
 /// ending only when the connection to the topic is severed.
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 pub struct Consumer {
-    pub offsets: Option<Vec<Offset>>,
+    pub offsets: Option<Vec<ConsumerOffset>>,
     pub subscriptions: Option<Vec<Subscription>>,
 }
 
@@ -110,7 +110,7 @@ pub trait CommitLog {
     fn scoped_subscribe<'a>(
         &'a self,
         consumer_group_name: &str,
-        offsets: Option<&[Offset]>,
+        offsets: Option<&[ConsumerOffset]>,
         subscriptions: Option<&[Subscription]>,
         idle_timeout: Option<Duration>,
     ) -> Pin<Box<dyn Stream<Item = ConsumerRecord> + 'a>>;

--- a/src/kafka/mod.rs
+++ b/src/kafka/mod.rs
@@ -16,7 +16,7 @@ use serde::Serialize;
 use tokio::time;
 use tokio_stream::Stream;
 
-use crate::commit_log::Offset;
+use crate::commit_log::ConsumerOffset;
 use crate::commit_log::ProducedOffset;
 use crate::commit_log::ProducerError;
 use crate::commit_log::ProducerRecord;
@@ -98,7 +98,7 @@ impl CommitLog for KafkaRestCommitLog {
     fn scoped_subscribe<'a>(
         &'a self,
         consumer_group_name: &str,
-        offsets: Option<&[Offset]>,
+        offsets: Option<&[ConsumerOffset]>,
         subscriptions: Option<&[Subscription]>,
         idle_timeout: Option<Duration>,
     ) -> Pin<Box<dyn Stream<Item = ConsumerRecord> + 'a>> {

--- a/src/kafka/mod.rs
+++ b/src/kafka/mod.rs
@@ -39,6 +39,11 @@ const TOPIC_LABEL: &str = "topic";
 const RETRY_DELAY: Duration = Duration::from_millis(100);
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+struct ProduceRequest {
+    pub records: Vec<ProducerRecord>,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 struct ProduceReply {
     pub offsets: Vec<ProducedOffset>,
 }
@@ -166,7 +171,9 @@ impl CommitLog for KafkaRestCommitLog {
                     .join(&format!("/topics/{}", record.topic))
                     .unwrap(),
             )
-            .json(&record)
+            .json(&ProduceRequest {
+                records: vec![record.clone()],
+            })
             .send()
             .await
         {

--- a/src/secret_store.rs
+++ b/src/secret_store.rs
@@ -1,6 +1,7 @@
-/// Secret store behavior modelled off of the Hashicorp Vault HTTP API,
-/// but that which facilitates various backend implementations (including
-/// those that do not use HTTP).
+//! Secret store behavior modelled off of the Hashicorp Vault HTTP API,
+//! but that which facilitates various backend implementations (including
+//! those that do not use HTTP).
+
 use std::collections::HashMap;
 
 use async_trait::async_trait;

--- a/src/vault/mod.rs
+++ b/src/vault/mod.rs
@@ -1,5 +1,6 @@
-/// Provides an implementation of the secret store to be used with the
-/// [Hashicorp Vault Api](https://www.vaultproject.io/api-docs).
+//! Provides an implementation of the secret store to be used with the
+//! [Hashicorp Vault Api](https://www.vaultproject.io/api-docs).
+
 use std::{
     sync::{Arc, Once},
     time::Duration,

--- a/tests/commit_log.rs
+++ b/tests/commit_log.rs
@@ -23,7 +23,7 @@ async fn kafka_rest_scoped_subscribe() {
         assert_eq!(
             req_body,
             Consumer {
-                offsets: Some(vec!(Offset {
+                offsets: Some(vec!(ConsumerOffset {
                     topic: "default:end-device-events".to_string(),
                     partition: 0,
                     offset: 0,
@@ -81,7 +81,7 @@ async fn kafka_rest_scoped_subscribe() {
 
     let events = cl.scoped_subscribe(
         "farmo-integrator",
-        Some(&[Offset {
+        Some(&[ConsumerOffset {
             topic: "default:end-device-events".to_string(),
             partition: 0,
             offset: 0,


### PR DESCRIPTION
Prior to this PR, we could only consume from a commit log. The changes here permit a commit log to be produced to with records. The HTTP API conforms to the Kafka REST API.