### PR TITLE
Provide common args for streambed components

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -57,6 +57,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "atty"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -132,6 +143,45 @@ checksum = "d1873270f8f7942c191139cb8a40fd228da6c3fd2fc376d7e92d47aa14aeb59e"
 dependencies = [
  "crypto-common",
  "inout",
+]
+
+[[package]]
+name = "clap"
+version = "3.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3dbbb6653e7c55cc8595ad3e1f7be8f32aba4eb7ff7f0fd1163d4f3d137c0a9"
+dependencies = [
+ "atty",
+ "bitflags",
+ "clap_derive",
+ "clap_lex",
+ "indexmap",
+ "once_cell",
+ "strsim",
+ "termcolor",
+ "textwrap",
+]
+
+[[package]]
+name = "clap_derive"
+version = "3.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ba52acd3b0a5c33aeada5cdaa3267cdc7c594a98731d4268cdc1532f4264cb4"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
+dependencies = [
+ "os_str_bytes",
 ]
 
 [[package]]
@@ -361,6 +411,12 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
+name = "heck"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
 
 [[package]]
 name = "hermit-abi"
@@ -705,6 +761,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "os_str_bytes"
+version = "6.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "648001efe5d5c0102d8cea768e348da85d90af8ba91f0bea908f157951493cd4"
+
+[[package]]
 name = "parking_lot"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -762,6 +824,30 @@ name = "ppv-lite86"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
+
+[[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -998,6 +1084,7 @@ dependencies = [
  "base64",
  "cache_loader_async",
  "chrono",
+ "clap",
  "hex",
  "http",
  "humantime",
@@ -1011,6 +1098,12 @@ dependencies = [
  "tokio",
  "tokio-stream",
 ]
+
+[[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
@@ -1036,6 +1129,21 @@ dependencies = [
  "remove_dir_all",
  "winapi",
 ]
+
+[[package]]
+name = "termcolor"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
+name = "textwrap"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
 
 [[package]]
 name = "thiserror"
@@ -1346,6 +1454,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ async-trait = "0.1"
 base64 = "0.13"
 cache_loader_async = { version = "0.2.0", features = ["lru-cache", "ttl-cache"] }
 chrono = { version = "0.4", features = ["serde"] }
+clap = { version = "3.2", features = ["derive", "env"] }
 hex = "0.4"
 humantime = "2.1"
 log = "0.4"

--- a/src/kafka/args.rs
+++ b/src/kafka/args.rs
@@ -1,0 +1,34 @@
+//! Provides command line arguments that are typically used for all services using this module.
+
+use std::path::PathBuf;
+
+use clap::Parser;
+use reqwest::Url;
+
+#[derive(Parser, Debug)]
+pub struct CommitLogArgs {
+    /// The amount of time to indicate that no more events are immediately
+    /// available from the Commit Log endpoint
+    #[clap(env, long, default_value = "100ms")]
+    pub cl_idle_timeout: humantime::Duration,
+
+    /// A namespace to connect to
+    #[clap(env, long)]
+    pub cl_namespace: Option<String>,
+
+    /// A namespace to use when communicating with the Commit Log
+    #[clap(env, long, default_value = "default")]
+    pub cl_ns: String,
+
+    /// A URL of the Commit Log RESTful Kafka server to communicate with
+    #[clap(env, long, default_value = "http://localhost:8082")]
+    pub cl_server: Url,
+
+    /// A path to a TLS cert pem file to be used for connecting with the Commit Log server.
+    #[clap(env, long)]
+    pub cl_server_cert_path: Option<PathBuf>,
+
+    /// Insecurely trust the Commit Log's TLS certificate
+    #[clap(env, long)]
+    pub cl_server_insecure: bool,
+}

--- a/src/kafka/mod.rs
+++ b/src/kafka/mod.rs
@@ -1,5 +1,7 @@
 //! Provides commit log functionality to connect with the Kafka HTTP API
 
+pub mod args;
+
 use std::pin::Pin;
 use std::sync::Once;
 use std::time::Duration;

--- a/src/state_storage/args.rs
+++ b/src/state_storage/args.rs
@@ -1,0 +1,16 @@
+//! Provides command line arguments that are typically used for all services using this module.
+
+use std::path::PathBuf;
+
+use clap::Parser;
+
+#[derive(Parser, Debug)]
+pub struct StateStorageArgs {
+    /// A file system path to where state may be stored
+    #[clap(env, long, default_value = "/var/run/farmo-integrator")]
+    pub state_storage_path: PathBuf,
+
+    /// The interval between connecting to the commit-log-server and storing our state.
+    #[clap(env, long, default_value = "1m")]
+    pub state_store_interval: humantime::Duration,
+}

--- a/src/state_storage/mod.rs
+++ b/src/state_storage/mod.rs
@@ -1,0 +1,55 @@
+//! Functionality for loading an persisting structures
+
+pub mod args;
+
+use crate::{decrypt_buf, encrypt_struct, secret_store};
+use rand::RngCore;
+use serde::{de::DeserializeOwned, Serialize};
+use std::{error::Error, path::Path};
+use tokio::{
+    fs,
+    io::{AsyncReadExt, AsyncWriteExt},
+};
+
+/// Loads and deserializes a structure described by T, if the file is present.
+/// If there are IO issues outside of the file not being there, they will be returned
+/// as an error. Beyond IO, state is attempted to be decrypted and deserialized when present.
+/// Any issues there cause the default representation of the structure to be returned. The default
+/// structure is also returned where there is no file present in the first place.
+pub async fn load_struct<T>(
+    state_storage_path: &Path,
+    ss: &impl secret_store::SecretStore,
+    secret_path: &str,
+) -> Result<T, Box<dyn Error>>
+where
+    T: Default + DeserializeOwned,
+{
+    if let Ok(mut f) = fs::File::open(state_storage_path).await {
+        let mut buf = vec![];
+        f.read_to_end(&mut buf).await?;
+        Ok(decrypt_buf(ss, secret_path, &mut buf)
+            .await
+            .unwrap_or_default())
+    } else {
+        Ok(T::default())
+    }
+}
+
+/// Saves an encrypted structure described by T. Any IO errors are returned.
+pub async fn save_struct<T, U>(
+    state_storage_path: &Path,
+    ss: &impl secret_store::SecretStore,
+    secret_path: &str,
+    rng: &mut U,
+    state: &T,
+) -> Result<(), Box<dyn Error>>
+where
+    T: Serialize,
+    U: RngCore,
+{
+    if let Some(buf) = encrypt_struct(ss, secret_path, rng, state).await {
+        let mut f = fs::File::create(state_storage_path).await?;
+        f.write_all(&buf).await?;
+    }
+    Ok(())
+}

--- a/src/vault/args.rs
+++ b/src/vault/args.rs
@@ -1,0 +1,53 @@
+//! Provides command line arguments that are typically used for all services using this module.
+
+use std::path::PathBuf;
+
+use clap::Parser;
+use reqwest::Url;
+
+#[derive(Parser, Debug)]
+pub struct SsArgs {
+    /// The max number of Vault Secret Store secrets to retain by our cache at any time.
+    /// Least Recently Used (LRU) secrets will be evicted from our cache once this value
+    /// is exceeded.
+    #[clap(env, long, default_value_t = 10_000)]
+    pub ss_max_secrets: usize,
+
+    /// A namespace to use when communicating with the Vault Secret Store
+    #[clap(env, long, default_value = "default")]
+    pub ss_ns: String,
+
+    /// The Vault Secret Store role_id to use for approle authentication.
+    #[clap(env, long)]
+    pub ss_role_id: String,
+
+    /// A URL of the Vault Secret Store server to communicate with
+    #[clap(env, long, default_value = "http://localhost:9876")]
+    pub ss_server: Url,
+
+    /// A path to a TLS cert pem file to be used for connecting with the Vault Secret Store server.
+    #[clap(env, long)]
+    pub ss_server_cert_path: Option<PathBuf>,
+
+    /// Insecurely trust the Secret Store's TLS certificate
+    #[clap(env, long)]
+    pub ss_server_insecure: bool,
+
+    /// A data field to used in place of Vault's lease_duration field. Time
+    /// will be interpreted as a humantime string e.g. "1m", "1s" etc. Note
+    /// that v2 of the Vault server does not appear to populate the lease_duration
+    /// field for the KV secret store any longer. Instead, we can use a "ttl" field
+    /// from the data.
+    #[clap(env, long)]
+    pub ss_ttl_field: Option<String>,
+
+    /// How long we wait until re-requesting the Vault Secret Store server for an
+    /// authentication given a bad auth prior.
+    #[clap(env, long, default_value = "1m")]
+    pub ss_unauthenticated_timeout: humantime::Duration,
+
+    /// How long we wait until re-requesting the Vault Secret Store server for an
+    /// unauthorized secret again.
+    #[clap(env, long, default_value = "1m")]
+    pub ss_unauthorized_timeout: humantime::Duration,
+}

--- a/src/vault/mod.rs
+++ b/src/vault/mod.rs
@@ -1,6 +1,8 @@
 //! Provides an implementation of the secret store to be used with the
 //! [Hashicorp Vault Api](https://www.vaultproject.io/api-docs).
 
+pub mod args;
+
 use std::{
     sync::{Arc, Once},
     time::Duration,


### PR DESCRIPTION
We now provide common Clap based arguments for various components within Streambed. This saves each service having to redeclare them.