### PR TITLE
Include retries and offset retrieval

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,7 +19,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.7",
  "once_cell",
  "version_check",
 ]
@@ -229,6 +229,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "exponential-backoff"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "851c5c1b202b7317c442c5f9c1f55f4cb6cb7e3dee875dd422d124c081a8da88"
+dependencies = [
+ "rand 0.7.3",
+]
+
+[[package]]
 name = "fastrand"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -365,6 +374,17 @@ checksum = "fd48d33ec7f05fbfa152300fdad764757cbded343c1aa1cff2fbaf4134851803"
 dependencies = [
  "typenum",
  "version_check",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi 0.9.0+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -869,13 +889,36 @@ dependencies = [
 
 [[package]]
 name = "rand"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
+dependencies = [
+ "getrandom 0.1.16",
+ "libc",
+ "rand_chacha 0.2.2",
+ "rand_core 0.5.1",
+ "rand_hc",
+]
+
+[[package]]
+name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.3",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.5.1",
 ]
 
 [[package]]
@@ -885,7 +928,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.3",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
+dependencies = [
+ "getrandom 0.1.16",
 ]
 
 [[package]]
@@ -894,7 +946,16 @@ version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.7",
+]
+
+[[package]]
+name = "rand_hc"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
+dependencies = [
+ "rand_core 0.5.1",
 ]
 
 [[package]]
@@ -1085,13 +1146,14 @@ dependencies = [
  "cache_loader_async",
  "chrono",
  "clap",
+ "exponential-backoff",
  "hex",
  "http",
  "humantime",
  "hyper",
  "log",
  "metrics",
- "rand",
+ "rand 0.8.5",
  "reqwest",
  "serde",
  "serde_json",
@@ -1350,6 +1412,12 @@ dependencies = [
  "log",
  "try-lock",
 ]
+
+[[package]]
+name = "wasi"
+version = "0.9.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ base64 = "0.13"
 cache_loader_async = { version = "0.2.0", features = ["lru-cache", "ttl-cache"] }
 chrono = { version = "0.4", features = ["serde"] }
 clap = { version = "3.2", features = ["derive", "env"] }
+exponential-backoff = "1.1"
 hex = "0.4"
 humantime = "2.1"
 log = "0.4"

--- a/src/delayer.rs
+++ b/src/delayer.rs
@@ -1,0 +1,34 @@
+// Utility for delaying with exponential backoff. Once retries have
+// been attained then we start again. There are a hard set of values
+// here as it is private within Streambed.
+
+use std::time::Duration;
+
+use exponential_backoff::Backoff;
+use tokio::time;
+
+pub(crate) struct Delayer {
+    backoff: Backoff,
+    retry_attempt: u32,
+}
+
+impl Delayer {
+    pub fn new() -> Self {
+        let backoff = Backoff::new(8, Duration::from_millis(100), Duration::from_secs(10));
+        Self {
+            backoff,
+            retry_attempt: 0,
+        }
+    }
+
+    pub async fn delay(&mut self) {
+        let delay = if let Some(d) = self.backoff.next(self.retry_attempt) {
+            d
+        } else {
+            self.retry_attempt = 0;
+            self.backoff.next(self.retry_attempt).unwrap()
+        };
+        time::sleep(delay).await;
+        self.retry_attempt = self.retry_attempt.wrapping_add(1);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,6 +30,8 @@
 
 pub mod state_storage;
 
+mod delayer;
+
 use std::time::Duration;
 use std::{error::Error, path::Path};
 

--- a/src/secret_store.rs
+++ b/src/secret_store.rs
@@ -37,12 +37,11 @@ pub struct SecretData {
 pub enum Error {
     /// The secret store is not authenticated.
     Unauthorized,
-    /// The secret store is unavailable at this time. Try later.
-    Unavailable,
 }
 
 /// Describes a secret store modelled on the Hashicorp Vault API,
 /// but one that can be backended with other implementations.
+/// Connections are managed and retried if they cannot be established.
 #[async_trait]
 pub trait SecretStore {
     /// Perform an app authentication given a role and secret. If successful, then the


### PR DESCRIPTION
Streambed components for the commit log and secret store now manage their respective connections entirely, including an exponential backoff mechanism. Prior to this PR, only one function of the commit log managed the connection.

In addition, a new `offsets` method is provided to obtain the offsets given a topic and partition. Conforms to the Kafka REST API.