### PR TITLE
Updates subscriptions

### DIFF
--- a/src/commit_log.rs
+++ b/src/commit_log.rs
@@ -49,7 +49,7 @@ pub struct Subscription {
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 pub struct Consumer {
     pub offsets: Option<Vec<ConsumerOffset>>,
-    pub subscriptions: Option<Vec<Subscription>>,
+    pub subscriptions: Vec<Subscription>,
 }
 
 /// A declaration of a record produced by a subscription
@@ -116,7 +116,7 @@ pub trait CommitLog {
         &'a self,
         consumer_group_name: &str,
         offsets: Option<&[ConsumerOffset]>,
-        subscriptions: Option<&[Subscription]>,
+        subscriptions: &[Subscription],
         idle_timeout: Option<Duration>,
     ) -> Pin<Box<dyn Stream<Item = ConsumerRecord> + 'a>>;
 }


### PR DESCRIPTION
As records are consumed, we now update the offsets we observe per topic/partition. If we then must re-subscribe given a loss of connectivity, we use the updated offsets as our starting point. If we did not do this then we would start consuming from our original start point each time.

The subscriptions argument has also had its optionality removed. There's no point in subscribing with no subscriptions!

Finally, if we do re-connect given no more chunks then we reset the delayer so that we can attempt to resume asap. I've noticed that reqwest (or hyper) times out the request after a little - which is probably good from a proxying/connection perspective. Thus, it is a normal condition to receive no chunk and then have to re-connect.

The tests have been updated to ensure that the consumer idle behaviour works properly.