### PR TITLE
Introduces a maximum lease duration for the Vault-based secret store

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -92,6 +92,7 @@ pub async fn authenticate_secret_store(
     role_id: &str,
     secret_id: &str,
     unauthenticated_timeout: Duration,
+    max_lease_duration: Duration,
 ) -> AuthenticationTask {
     let mut approle_auth_reply = ss.approle_auth(role_id, secret_id).await;
     let auth_role_id = role_id.to_string();
@@ -111,7 +112,7 @@ pub async fn authenticate_secret_store(
                     }
                     tokio::select! {
                         _ = task_termination.notified() => break,
-                        _ = time::sleep(Duration::from_secs(approle_auth.auth.lease_duration)) => {
+                        _ = time::sleep(Duration::from_secs(approle_auth.auth.lease_duration).min(max_lease_duration)) => {
                             approle_auth_reply = ss.approle_auth(&auth_role_id, &auth_secret_id).await;
                         }
                     }

--- a/src/vault/args.rs
+++ b/src/vault/args.rs
@@ -7,6 +7,14 @@ use reqwest::Url;
 
 #[derive(Parser, Debug)]
 pub struct SsArgs {
+    /// The maximum time we allow for a lease to expire. This is important to curb
+    /// situations where the secret store is not honoring a previously advised
+    /// lease duration for some reason. While this should never happen, given the
+    /// nature of the secret store being in a separate process, it technically
+    /// can happen (and has!).
+    #[clap(env, long, default_value = "30m")]
+    pub ss_max_lease_duration: humantime::Duration,
+
     /// The max number of Vault Secret Store secrets to retain by our cache at any time.
     /// Least Recently Used (LRU) secrets will be evicted from our cache once this value
     /// is exceeded.


### PR DESCRIPTION
We can't trust a remote secret store to guarantee that it will honour a lease duration on an authenticated token. As a fail-safe, we limit the time that we hold on to an authentication token.

While the secret service should always guarantee an authentication token lease, we have had a long-standing bug in our JVM secret service where it doesn't. In addition, our JVM secret service doesn't support app role authentication and returns user/password TTLs of 7 days for human convenience. Vault's documentation also recommends shorter TTLs to avoid memory exhaustion during their purging. There's no official statement on the amount of time the max should be, but I saw some Vault examples show 30 minutes. These values can always be overridden; the change here is to permit a maximum and facilitate it to be changed.

For more info: https://learn.hashicorp.com/tutorials/vault/approle-best-practices?in=vault/auth-methods#token-lifetime-considerations