### PR TITLE
Adds ask pattern

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1577,6 +1577,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "streambed-patterns"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "tokio",
+]
+
+[[package]]
 name = "streambed-storage"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "streambed-confidant",
     "streambed-kafka",
     "streambed-logged",
+    "streambed-patterns",
     "streambed-storage",
     "streambed-test",
     "streambed-vault",

--- a/streambed-patterns/Cargo.toml
+++ b/streambed-patterns/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "streambed-patterns"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+async-trait = { workspace = true }
+tokio = { workspace = true, features = ["full"] }

--- a/streambed-patterns/README.md
+++ b/streambed-patterns/README.md
@@ -1,3 +1,10 @@
 # patterns
 
 Patterns for working with streambed.
+
+## Ask Pattern
+
+The ask pattern is based on the concept of the same name from [Akka](https://doc.akka.io/docs/akka/current/stream/operators/Source-or-Flow/ask.html).
+It encodes async request-reply semantics which can be used, for example, to perform request-reply operations across a `tokio::sync::mpsc::channel` or
+similar. The provided implementation sends a message using a `tokio::sync::mpsc::Sender<_>` and uses a `tokio::sync::oneshot` channel internally to convey the
+response.

--- a/streambed-patterns/README.md
+++ b/streambed-patterns/README.md
@@ -1,0 +1,3 @@
+# patterns
+
+Patterns for working with streambed.

--- a/streambed-patterns/examples/ask.rs
+++ b/streambed-patterns/examples/ask.rs
@@ -1,0 +1,50 @@
+use crate::ExampleCommand::{GetState, SetState};
+use std::error::Error;
+use streambed_patterns::ask::Ask;
+
+enum ExampleCommand {
+    GetState {
+        reply_to: Box<dyn FnOnce(String) + Send>,
+    },
+    SetState {
+        new_state: String,
+    },
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn Error>> {
+    let (tx, mut rx) = tokio::sync::mpsc::channel::<ExampleCommand>(1);
+
+    tokio::spawn(async move {
+        let mut state = "initial state".to_string();
+
+        while let Some(msg) = rx.recv().await {
+            match msg {
+                GetState { reply_to } => {
+                    reply_to(state.clone());
+                }
+                SetState { new_state } => {
+                    state = new_state;
+                }
+            }
+        }
+    });
+
+    // Use the ask pattern to get the state
+    let state = tx.ask(|reply_to| GetState { reply_to }).await.unwrap();
+    println!("state: {state}");
+
+    // Set the state to something different
+    let _ = tx
+        .send(SetState {
+            new_state: "new state".to_string(),
+        })
+        .await;
+    println!("state updated");
+
+    // Use the ask pattern to get the state again
+    let state = tx.ask(|reply_to| GetState { reply_to }).await.unwrap();
+    println!("state: {state}");
+
+    Ok(())
+}

--- a/streambed-patterns/src/ask.rs
+++ b/streambed-patterns/src/ask.rs
@@ -1,0 +1,59 @@
+use async_trait::async_trait;
+use std::error::Error;
+use std::fmt::{Debug, Display, Formatter};
+use tokio::sync::{mpsc, oneshot};
+
+#[derive(Debug)]
+pub enum AskError {
+    SendError,
+    ReceiveError,
+}
+
+impl Display for AskError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            AskError::SendError => write!(f, "SendError"),
+            AskError::ReceiveError => write!(f, "ReceiveError"),
+        }
+    }
+}
+
+impl Error for AskError {}
+
+#[async_trait]
+pub trait Ask<A> {
+    /// The ask pattern is a way to send a message and get a response back.
+    async fn ask<R>(
+        &self,
+        f: impl FnOnce(Box<dyn FnOnce(R) + Send>) -> A + Send,
+    ) -> Result<R, AskError>
+    where
+        R: Send + 'static;
+}
+
+#[async_trait]
+impl<A> Ask<A> for mpsc::Sender<A>
+where
+    A: Send,
+{
+    /// This implementation of the ask pattern sends a message to a [tokio::sync::mpsc::Sender<_>]
+    /// and uses a [tokio::sync::oneshot] channel internally to convey the response.
+    async fn ask<R>(
+        &self,
+        f: impl FnOnce(Box<dyn FnOnce(R) + Send>) -> A + Send,
+    ) -> Result<R, AskError>
+    where
+        R: Send + 'static,
+    {
+        let (reply_to, receiver) = oneshot::channel();
+        let reply_to = Box::new(move |r| {
+            let _ = reply_to.send(r);
+        });
+
+        self.send(f(reply_to))
+            .await
+            .map_err(|_| AskError::SendError)?;
+
+        receiver.await.map_err(|_| AskError::ReceiveError)
+    }
+}

--- a/streambed-patterns/src/ask.rs
+++ b/streambed-patterns/src/ask.rs
@@ -23,11 +23,9 @@ impl Error for AskError {}
 #[async_trait]
 pub trait Ask<A> {
     /// The ask pattern is a way to send a message and get a response back.
-    async fn ask<R>(
-        &self,
-        f: impl FnOnce(Box<dyn FnOnce(R) + Send>) -> A + Send,
-    ) -> Result<R, AskError>
+    async fn ask<F, R>(&self, f: F) -> Result<R, AskError>
     where
+        F: FnOnce(Box<dyn FnOnce(R) + Send>) -> A + Send,
         R: Send + 'static;
 }
 
@@ -38,11 +36,9 @@ where
 {
     /// This implementation of the ask pattern sends a message to a [tokio::sync::mpsc::Sender<_>]
     /// and uses a [tokio::sync::oneshot] channel internally to convey the response.
-    async fn ask<R>(
-        &self,
-        f: impl FnOnce(Box<dyn FnOnce(R) + Send>) -> A + Send,
-    ) -> Result<R, AskError>
+    async fn ask<F, R>(&self, f: F) -> Result<R, AskError>
     where
+        F: FnOnce(Box<dyn FnOnce(R) + Send>) -> A + Send,
         R: Send + 'static,
     {
         let (reply_to, receiver) = oneshot::channel();

--- a/streambed-patterns/src/lib.rs
+++ b/streambed-patterns/src/lib.rs
@@ -1,0 +1,3 @@
+#![doc = include_str!("../README.md")]
+
+pub mod ask;


### PR DESCRIPTION
Adds a patterns crate to streambed along with an `Ask` trait and an implementation of this pattern. The ask pattern is based on the [concept of the same name from Akka](https://doc.akka.io/docs/akka/current/stream/operators/Source-or-Flow/ask.html). It encodes async request-reply semantics which can be used, for example, to perform request-reply operations across a `tokio::sync::mpsc::channel` or similar type. The provided implementation sends a message using a `tokio::sync::mpsc::Sender<_>` and uses a `tokio::sync::oneshot` channel internally to convey the response.