### PR TITLE
Permit serialisation to be generic

### DIFF
--- a/streambed-storage/src/lib.rs
+++ b/streambed-storage/src/lib.rs
@@ -16,18 +16,20 @@ use tokio::{
 /// as an error. Beyond IO, state is attempted to be decrypted and deserialized when present.
 /// Any issues there cause the default representation of the structure to be returned. The default
 /// structure is also returned where there is no file present in the first place.
-pub async fn load_struct<T>(
+pub async fn load_struct<T, D>(
     state_storage_path: &Path,
     ss: &impl secret_store::SecretStore,
     secret_path: &str,
+    deserialize: D,
 ) -> Result<T, Box<dyn Error>>
 where
     T: Default + DeserializeOwned,
+    D: FnOnce(&mut [u8]) -> Option<T>,
 {
     if let Ok(mut f) = fs::File::open(state_storage_path).await {
         let mut buf = vec![];
         f.read_to_end(&mut buf).await?;
-        Ok(decrypt_buf(ss, secret_path, &mut buf)
+        Ok(decrypt_buf(ss, secret_path, &mut buf, deserialize)
             .await
             .unwrap_or_default())
     } else {
@@ -36,19 +38,21 @@ where
 }
 
 /// Saves an encrypted structure described by T. Any IO errors are returned.
-pub async fn save_struct<T, U, F>(
+pub async fn save_struct<T, U, F, S>(
     state_storage_path: &Path,
     ss: &impl secret_store::SecretStore,
     secret_path: &str,
+    serialize: S,
     rng: F,
     state: &T,
 ) -> Result<(), Box<dyn Error>>
 where
     T: Serialize,
+    S: FnOnce(&T) -> Option<Vec<u8>>,
     F: FnOnce() -> U,
     U: RngCore,
 {
-    if let Some(buf) = encrypt_struct(ss, secret_path, rng, state).await {
+    if let Some(buf) = encrypt_struct(ss, secret_path, serialize, rng, state).await {
         let mut f = fs::File::create(state_storage_path).await?;
         f.write_all(&buf).await?;
     }

--- a/streambed/Cargo.toml
+++ b/streambed/Cargo.toml
@@ -16,8 +16,10 @@ log = { workspace = true }
 rand = { workspace = true }
 reqwest = { workspace = true, features = ["json"] }
 serde = { workspace = true, features = ["derive"] }
-serde_json = { workspace = true }
 serde_with = { workspace = true, features = ["base64"] }
 sha2 = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 tokio-stream = { workspace = true }
+
+[dev-dependencies]
+serde_json = { workspace = true }


### PR DESCRIPTION
Let's avoid dictating that JSON should be used for encrypted structs