### PR TITLE
Permit the init function of compaction to be async

### DIFF
--- a/streambed-kafka/src/lib.rs
+++ b/streambed-kafka/src/lib.rs
@@ -29,6 +29,7 @@ use tokio::time;
 use tokio_stream::Stream;
 
 /// A commit log holds topics and can be appended to and tailed.
+#[derive(Clone)]
 pub struct KafkaRestCommitLog {
     client: Client,
     server: Url,

--- a/streambed-logged/src/lib.rs
+++ b/streambed-logged/src/lib.rs
@@ -160,7 +160,7 @@ impl FileLog {
         compaction_strategy: CS,
     ) -> Result<(), CompactionRegistrationError>
     where
-        CS: CompactionStrategy + Send + 'static,
+        CS: CompactionStrategy + Send + Sync + 'static,
     {
         let topic_file_op = {
             let Ok(mut locked_topic_file_ops) = self.topic_file_ops.lock() else {return Err(CompactionRegistrationError)};

--- a/streambed/src/commit_log.rs
+++ b/streambed/src/commit_log.rs
@@ -126,7 +126,7 @@ pub enum ProducerError {
 /// A commit log holds topics and can be appended to and tailed.
 /// Connections are managed and retried if they cannot be established.
 #[async_trait]
-pub trait CommitLog {
+pub trait CommitLog: Clone + Send + Sync {
     /// Retrieve the current offsets of a topic if they are present.
     async fn offsets(&self, topic: Topic, partition: Partition) -> Option<PartitionOffsets>;
 

--- a/streambed/src/secret_store.rs
+++ b/streambed/src/secret_store.rs
@@ -49,7 +49,7 @@ pub enum Error {
 /// but one that can be backended with other implementations.
 /// Connections are managed and retried if they cannot be established.
 #[async_trait]
-pub trait SecretStore {
+pub trait SecretStore: Clone + Send + Sync {
     /// Perform an app authentication given a role and secret. If successful, then the
     /// secret store will be updated with a client token thereby permitting subsequent
     /// operations including getting secrets.


### PR DESCRIPTION
Without async, it is difficult to put together a compaction strategy that needs to resolve a secret key, for example. Secrets need to be resolved to decrypt record contents, which we like to avoid, but it is possible.

Also declares the commit log and secret store to be clone, send and sync, because they are safely so.