### PR TITLE
Recover compaction

### DIFF
--- a/streambed-logged/src/lib.rs
+++ b/streambed-logged/src/lib.rs
@@ -170,6 +170,7 @@ impl FileLog {
         let mut age_active_file_topic_file_op = topic_file_op.clone();
         let age_active_file_read_buffer_size = self.read_buffer_size;
         let new_work_file_topic_file_op = topic_file_op.clone();
+        let recover_history_files_topic_file_op = topic_file_op.clone();
         let replace_history_files_topic_file_op = topic_file_op;
 
         let compaction_write_buffer_size = self.compaction_write_buffer_size;
@@ -190,6 +191,7 @@ impl FileLog {
                     .map_err(TopicFileOpError::IoError)
                 },
                 move || new_work_file_topic_file_op.new_work_file(compaction_write_buffer_size),
+                move || recover_history_files_topic_file_op.recover_history_files(),
                 move || replace_history_files_topic_file_op.replace_history_files(),
             ),
         );

--- a/streambed-logged/src/topic_file_op.rs
+++ b/streambed-logged/src/topic_file_op.rs
@@ -156,6 +156,17 @@ impl TopicFileOp {
             .map_err(TopicFileOpError::IoError)
     }
 
+    pub fn recover_history_files(&self) -> Result<(), TopicFileOpError> {
+        let present_path = self.root_path.join(self.topic.clone());
+        let work_path = present_path.with_extension(WORK_FILE_EXTENSION);
+        let ancient_history_path = present_path.with_extension(ANCIENT_HISTORY_FILE_EXTENSION);
+        let history_path = present_path.with_extension(HISTORY_FILE_EXTENSION);
+
+        let _ = fs::rename(ancient_history_path, history_path);
+        let _ = fs::remove_file(work_path);
+        Ok(())
+    }
+
     pub fn replace_history_files(&self) -> Result<(), TopicFileOpError> {
         let present_path = self.root_path.join(self.topic.clone());
         let work_path = present_path.with_extension(WORK_FILE_EXTENSION);


### PR DESCRIPTION
If compaction had not finished when it was stopped, then restore things to a state where compaction may begin again. This may help avoid any weird corruption due to moving files between stopping and starting. I tested this against a corrupt history file and it worked well and seems like a reasonable thing to do no matter what.

Fixes #40 - note that we don't attempt to fix reading a corrupt write in general though - all bets are off in this scenario, and a hard reset may be required. I'm unsure how a corrupt write can occur with a journaled file system.