### PR TITLE
Tolerate more topic corruption

### DIFF
--- a/streambed-logged/benches/benches.rs
+++ b/streambed-logged/benches/benches.rs
@@ -1,3 +1,5 @@
+use std::thread;
+use std::time::Duration;
 use std::{env, fs};
 
 use criterion::{criterion_group, criterion_main, Criterion};
@@ -82,6 +84,9 @@ fn criterion_benchmark(c: &mut Criterion) {
                 .unwrap();
             }
         });
+
+        // Provide time for the writes to be flushed
+        thread::sleep(Duration::from_secs(1));
 
         b.to_async(&rt).iter(|| {
             let task_cl = cl.clone();

--- a/streambed-logged/src/topic_file_op.rs
+++ b/streambed-logged/src/topic_file_op.rs
@@ -113,6 +113,14 @@ impl TopicFileOp {
         r.map(|_| ()).map_err(TopicFileOpError::IoError)
     }
 
+    pub fn open_active_file(&self, open_options: OpenOptions) -> Result<File, TopicFileOpError> {
+        let Ok(locked_write_handle) = self.write_handle.lock() else {return Err(TopicFileOpError::CannotLock)};
+        let present_path = self.root_path.join(self.topic.clone());
+        let r = open_options.open(present_path);
+        drop(locked_write_handle);
+        r.map_err(TopicFileOpError::IoError)
+    }
+
     pub fn open_files(
         &self,
         open_options: OpenOptions,


### PR DESCRIPTION
There are three changes here. First, when we initially produce to a topic, we now handle the `find_offsets` function returning an error instead of ignoring it. Second, we stay subscribed to a topic with the view that it will be recovered. Third, we need to exhaust decoding before reading more into our buffers... otherwise memory can grow.

The `find_offsets` function returns an error if it can't decode a record (amongst other things). The new logic will detect this error and truncate the active file to the length at which records can be decoded to. It will then attempt another pass with `find_offsets`. If this second pass fails then any producer will receive a `CannotProduce` error. I also discovered that only the first producer to a topic would receive this error, so this is an improvement as there can be multiple producers to the same topic.

The subscriptions will now behave in a similar fashion to when our Kafka flavour of the commit log can't connect... it will just keep trying with the view that something will recover it.

One case not addressed directly by the changes here is when anything other than the active file becomes corrupt. I'm not sure that can happen though, and we do have logic from a previous commit where incomplete compaction can now recover.

TODO:

* [x] test