### PR TITLE
Increase the default max record size

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,30 +8,21 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  RUSTFLAGS: -Dwarnings
 
 jobs:
   build:
-
     runs-on: ubuntu-20.04
 
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/cache@v3
-      with:
-        path: |
-          ./.cargo/registry/index
-          ./.cargo/registry/cache
-          ./.cargo/git
-          target
-        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-    - uses: actions-rs/toolchain@v1
-      with:
-        toolchain: stable
-        override: true
-        components: rustfmt, clippy
-    - name: Format and lint
-      env:
-        RUSTFLAGS: -Dwarnings
-      run: cargo fmt -- --check && cargo clippy --verbose
-    - name: Run tests
-      run: cargo test --verbose
+    - uses: actions/checkout@v2
+    - name: Update Rust
+      run: |
+        rustup update
+    - uses: Swatinem/rust-cache@v2
+          
+    - name: Format, lint and test
+      run: |
+        cargo fmt -- --check
+        cargo clippy --verbose
+        cargo test --verbose

--- a/streambed-logged/src/lib.rs
+++ b/streambed-logged/src/lib.rs
@@ -106,7 +106,7 @@ impl FileLog {
     where
         P: Into<PathBuf>,
     {
-        Self::with_config(root_path, 64 * 1024, 8192, 64 * 1024, 8192, 8192)
+        Self::with_config(root_path, 64 * 1024, 8192, 64 * 1024, 8 * 1024, 16 * 1024)
     }
 
     /// Construct a new file log that will also spawn a task for each


### PR DESCRIPTION
This copes with 11KiB records being found in the wild.

Also modernises our CI build as per how we're doing this elsewhere.