### PR TITLE
Express streambed types using protobuf

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+    "protoc": {
+        "options": [
+            "--proto_path=${workspaceRoot}/streambed-proto/src"
+        ]
+    }
+}

--- a/streambed-proto/README.md
+++ b/streambed-proto/README.md
@@ -1,0 +1,10 @@
+streambed-proto
+===
+
+Declares a set of interfaces suitable for serialising aspects of Streambed, such as those of the commit log.
+
+To compile, upon having installed `protoc`:
+
+```
+protoc src/stdce.proto -Isrc --cpp_out=target
+```

--- a/streambed-proto/src/commit_log.proto
+++ b/streambed-proto/src/commit_log.proto
@@ -10,7 +10,7 @@ import "google/protobuf/timestamp.proto";
 // A header provides a means of augmenting a record with
 // meta-data.
 message Header {
-    string key = 1;
+    uint64 key = 1;
     bytes value = 2;
 }
 
@@ -43,7 +43,7 @@ message ConsumerRecord {
     string topic = 1;
     repeated Header headers = 2;
     google.protobuf.Timestamp timestamp = 3;
-    string key= 4;
+    uint64 key= 4;
     bytes value = 5;
     uint32 partition = 6;
     uint64 offset = 7;
@@ -60,7 +60,7 @@ message ProducerRecord {
     string topic = 1;
     repeated Header headers = 2;
     google.protobuf.Timestamp timestamp = 3;
-    string key = 4;
+    uint64 key = 4;
     bytes value = 5;
     uint32 partition = 6;
 }

--- a/streambed-proto/src/commit_log.proto
+++ b/streambed-proto/src/commit_log.proto
@@ -1,0 +1,71 @@
+// Declares the types associated with a commit log,
+// heavily inspired by Apache Kafka.
+
+syntax = "proto3";
+
+package streambed.commit_log;
+
+import "google/protobuf/timestamp.proto";
+
+// A header provides a means of augmenting a record with
+// meta-data.
+message Header {
+    string key = 1;
+    bytes value = 2;
+}
+
+// A declaration of an offset to be committed to a topic.
+message ConsumerOffset {
+    string topic = 1;
+    uint32 partition = 2;
+    uint64 offset = 3;
+}
+
+// A declaration of a topic to subscribe to
+message Subscription {
+    string topic = 1;
+}
+
+// A declaration of a consumer group session to connect with.
+// In the case that offsets are supplied, these offsets are
+// associated with their respective topics such that any
+// subsequent subscription will source from the offset.
+// In the case where subscriptions are supplied, the consumer
+// instance will subscribe and reply with a stream of records
+// ending only when the connection to the topic is severed.
+message Consumer {
+    repeated ConsumerOffset offsets = 1;
+    repeated Subscription subscriptions = 2;
+}
+
+// A declaration of a record produced by a subscription
+message ConsumerRecord {
+    string topic = 1;
+    repeated Header headers = 2;
+    google.protobuf.Timestamp timestamp = 3;
+    string key= 4;
+    bytes value = 5;
+    uint32 partition = 6;
+    uint64 offset = 7;
+}
+
+// The reply to an offsets request
+message PartitionOffsets {
+    uint64 beginning_offset = 1;
+    uint64 end_offset = 2;
+}
+
+// A declaration of a record to be produced to a topic
+message ProducerRecord {
+    string topic = 1;
+    repeated Header headers = 2;
+    google.protobuf.Timestamp timestamp = 3;
+    string key = 4;
+    bytes value = 5;
+    uint32 partition = 6;
+}
+
+// The reply to a publish request
+message ProducedOffset {
+    uint64 offset = 1;
+}

--- a/streambed-proto/src/stdce.proto
+++ b/streambed-proto/src/stdce.proto
@@ -1,0 +1,44 @@
+// Standard commands and events.
+// See https://christopherhunt-software.blogspot.com/2023/06/introducing-standard-streamed-commands.html
+
+syntax = "proto3";
+
+package streambed.stdce;
+
+import "commit_log.proto";
+
+// Commands that can be received on stdin
+message Command {
+    // Handle a consumer record that has been received
+    message HandleConsumer {
+        streambed.commit_log.ConsumerRecord record = 1;
+    }
+    
+    // This will always be the first command delivered
+    // and indicates the partition offsets for each
+    // topic that been subscribed for the purposes of
+    // feeding records on stdin. The partition offsets
+    // can be used to determine when an end of events
+    // has been reached for event initialially event-
+    // sourcing state.
+    message HandleSubscription {
+        map<string, streambed.commit_log.PartitionOffsets> subscriptons = 1;
+    }
+
+    oneof command {
+        HandleConsumer handle_consumer = 10;
+        HandleSubscription handle_subscription = 11;
+    }
+}
+
+// Events that can be sent to stdout
+message Event {
+    // Records can be produced to a topic
+    message RecordProduced {
+        streambed.commit_log.ProducerRecord record = 1;
+    }
+
+    oneof event {
+        RecordProduced record_produced = 10;
+    }
+}


### PR DESCRIPTION
This commit introduces an idea where we may express Streambed types as protobuf. Doing so could enable a [stdce](https://christopherhunt-software.blogspot.com/2023/06/introducing-standard-streamed-commands.html) approach to consuming commands and producing events. In turn, this could lead to languages other than Rust being able to leverage Streambed, including streambed-logged.