### PR TITLE
Constain dependency feature flags further

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -581,6 +581,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
 
 [[package]]
+name = "embedded-io"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced"
+
+[[package]]
 name = "encoding_rs"
 version = "0.8.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -634,12 +640,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "1.9.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
-dependencies = [
- "instant",
-]
+checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
 
 [[package]]
 name = "fnv"
@@ -1041,26 +1044,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "instant"
-version = "0.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
-name = "io-lifetimes"
-version = "1.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
-dependencies = [
- "hermit-abi 0.3.2",
- "libc",
- "windows-sys",
-]
-
-[[package]]
 name = "iot-service"
 version = "0.1.0"
 dependencies = [
@@ -1099,7 +1082,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
 dependencies = [
  "hermit-abi 0.3.2",
- "rustix 0.38.4",
+ "rustix",
  "windows-sys",
 ]
 
@@ -1141,25 +1124,9 @@ checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.3.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
-
-[[package]]
-name = "linux-raw-sys"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09fc20d2ca12cb9f044c93e3bd6d32d523e6e2ec3db4f7b2939cd99026ecd3f0"
-
-[[package]]
-name = "lock_api"
-version = "0.4.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1cc9717a20b1bb222f333e6a92fd32f7d8a18ddc5a3191a11af45dcbf4dcd16"
-dependencies = [
- "autocfg",
- "scopeguard",
-]
 
 [[package]]
 name = "log"
@@ -1327,11 +1294,11 @@ checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
 
 [[package]]
 name = "openssl"
-version = "0.10.55"
+version = "0.10.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "345df152bc43501c5eb9e4654ff05f794effb78d4efe3d53abc158baddc0703d"
+checksum = "bac25ee399abb46215765b1cb35bc0212377e58a061560d8b29b024fd0430e7c"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.3.3",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -1359,9 +1326,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.90"
+version = "0.9.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "374533b0e45f3a7ced10fcaeccca020e66656bc03dac384f852e4e5a7a8104a6"
+checksum = "db4d56a4c0478783083cfafcc42493dd4a981d41669da64b4572a2a089b51b1d"
 dependencies = [
  "cc",
  "libc",
@@ -1374,29 +1341,6 @@ name = "os_str_bytes"
 version = "6.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d5d9eb14b174ee9aa2ef96dc2b94637a2d4b6e7cb873c7e171f0c20c6cf3eac"
-
-[[package]]
-name = "parking_lot"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
-dependencies = [
- "lock_api",
- "parking_lot_core",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.9.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93f00c865fe7cabf650081affecd3871070f26767e7b2070a3ffae14c654b447"
-dependencies = [
- "cfg-if",
- "libc",
- "redox_syscall",
- "smallvec",
- "windows-targets",
-]
 
 [[package]]
 name = "paste"
@@ -1493,11 +1437,13 @@ checksum = "edc55135a600d700580e406b4de0d59cb9ad25e344a3a091a97ded2622ec4ec6"
 
 [[package]]
 name = "postcard"
-version = "1.0.4"
-source = "git+https://github.com/jamesmunns/postcard.git?rev=a0ef8a2f90f53f1c30a554624c187a9672d098c9#a0ef8a2f90f53f1c30a554624c187a9672d098c9"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a55c51ee6c0db07e68448e336cf8ea4131a620edefebf9893e759b2d793420f8"
 dependencies = [
  "cobs",
  "crc",
+ "embedded-io",
  "paste",
  "serde",
 ]
@@ -1667,20 +1613,6 @@ checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
 
 [[package]]
 name = "rustix"
-version = "0.37.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d69718bf81c6127a49dc64e44a742e8bb9213c0ff8869a22c308f84c1d4ab06"
-dependencies = [
- "bitflags 1.3.2",
- "errno",
- "io-lifetimes",
- "libc",
- "linux-raw-sys 0.3.8",
- "windows-sys",
-]
-
-[[package]]
-name = "rustix"
 version = "0.38.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0a962918ea88d644592894bc6dc55acc6c0956488adcebbfb6e273506b7fd6e5"
@@ -1688,7 +1620,7 @@ dependencies = [
  "bitflags 2.3.3",
  "errno",
  "libc",
- "linux-raw-sys 0.4.3",
+ "linux-raw-sys",
  "windows-sys",
 ]
 
@@ -1739,9 +1671,9 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "security-framework"
-version = "2.9.1"
+version = "2.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fc758eb7bffce5b308734e9b0c1468893cae9ff70ebf13e7090be8dcbcc83a8"
+checksum = "05b64fb303737d99b81884b2c63433e9ae28abebe5eb5045dcdd175dc2ecf4de"
 dependencies = [
  "bitflags 1.3.2",
  "core-foundation",
@@ -1752,9 +1684,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.9.0"
+version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f51d0c0d83bec45f16480d0ce0058397a69e48fcdc52d1dc8855fb68acbd31a7"
+checksum = "e932934257d3b408ed8f30db49d85ea163bfe74961f017f405b025af298f0c7a"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -1854,15 +1786,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "signal-hook-registry"
-version = "1.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "slab"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1870,12 +1793,6 @@ checksum = "6528351c9bc8ab22353f9d776db39a20288e8d6c37ef8cfe3317cf875eecfc2d"
 dependencies = [
  "autocfg",
 ]
-
-[[package]]
-name = "smallvec"
-version = "1.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
 
 [[package]]
 name = "smol_str"
@@ -2087,15 +2004,14 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.6.0"
+version = "3.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31c0432476357e58790aaa47a8efb0c5138f137343f3b5f23bd36a27e3b0a6d6"
+checksum = "cb94d2f3cc536af71caac6b6fcebf65860b347e7ce0cc9ebe8f70d3e521054ef"
 dependencies = [
- "autocfg",
  "cfg-if",
  "fastrand",
  "redox_syscall",
- "rustix 0.37.23",
+ "rustix",
  "windows-sys",
 ]
 
@@ -2220,9 +2136,7 @@ dependencies = [
  "libc",
  "mio",
  "num_cpus",
- "parking_lot",
  "pin-project-lite",
- "signal-hook-registry",
  "socket2",
  "tokio-macros",
  "windows-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
+resolver = "2"
 
 members = [
     "streambed",
@@ -14,7 +15,7 @@ members = [
 ]
 
 [workspace.dependencies]
-aes ="0.8.2"
+aes = "0.8.2"
 async-stream = "0.3.3"
 async-trait = "0.1.60"
 base64 = "0.20.0"
@@ -35,9 +36,9 @@ humantime = "2.1.0"
 hyper = { version = "0.14.23", default-features = false }
 log = "0.4.17"
 metrics = { version = "0.20.1", default-features = false }
-postcard = { version = "1.0.2", default-features = false }
+postcard = { version = "1.0.8", default-features = false }
 rand = "0.8.5"
-reqwest = "0.11.13"
+reqwest = { version = "0.11.13" }
 scopeguard = "1.1"
 serde = "1.0.151"
 serde_json = "1.0.90"
@@ -45,11 +46,7 @@ serde_with = "2.0.1"
 sha2 = "0.10.6"
 smol_str = "0.2.0"
 test-log = "0.2.11"
-tokio = "1.23.0"
+tokio = { version = "1.23.0" }
 tokio-stream = "0.1.11"
 tokio-util = "0.7.4"
 warp = "0.3"
-
-
-[patch.crates-io]
-postcard = { git = "https://github.com/jamesmunns/postcard.git", rev = "a0ef8a2f90f53f1c30a554624c187a9672d098c9" }

--- a/examples/iot-service/Cargo.toml
+++ b/examples/iot-service/Cargo.toml
@@ -16,7 +16,13 @@ log = { workspace = true }
 postcard = { workspace = true, default-features = false, features = ["use-std"] }
 scopeguard = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
-tokio = { workspace = true, features = ["full"] }
+tokio = { workspace = true, features = [
+    "sync",
+    "macros",
+    "io-util",
+    "rt",
+    "time",
+] }
 tokio-stream = { workspace = true }
 tokio-util = { workspace = true, features = ["codec"] }
 warp = { workspace = true }

--- a/examples/iot-service/src/database.rs
+++ b/examples/iot-service/src/database.rs
@@ -65,7 +65,9 @@ pub async fn task(mut cl: FileLog, mut database_command_rx: mpsc::Receiver<Comma
                         let Some(timestamp) = record.timestamp else {
                             continue;
                         };
-                        let Ok(database_event) = ciborium::de::from_reader::<Event, _>(&*record.value) else {
+                        let Ok(database_event) =
+                            ciborium::de::from_reader::<Event, _>(&*record.value)
+                        else {
                             continue;
                         };
                         if events.len() == MAX_EVENTS_TO_REPLY {

--- a/examples/iot-service/src/http_server.rs
+++ b/examples/iot-service/src/http_server.rs
@@ -22,24 +22,25 @@ pub fn routes(
                         return warp::reply::with_status(
                             warp::reply::json(&"An id is required"),
                             StatusCode::BAD_REQUEST,
-                        )
+                        );
                     };
 
                     let Ok(id) = id.parse() else {
                         return warp::reply::with_status(
                             warp::reply::json(&"Invalid id - must be a number"),
                             StatusCode::BAD_REQUEST,
-                        )
+                        );
                     };
 
                     let Ok(events) = task_database_command_tx
                         .ask(|reply_to| database::Command::Get(id, reply_to))
-                        .await else {
-                            return warp::reply::with_status(
-                                warp::reply::json(&"Service unavailable"),
-                                StatusCode::SERVICE_UNAVAILABLE,
-                            )
-                         };
+                        .await
+                    else {
+                        return warp::reply::with_status(
+                            warp::reply::json(&"Service unavailable"),
+                            StatusCode::SERVICE_UNAVAILABLE,
+                        );
+                    };
 
                     warp::reply::with_status(warp::reply::json(&events), StatusCode::OK)
                 }

--- a/streambed-confidant/Cargo.toml
+++ b/streambed-confidant/Cargo.toml
@@ -14,7 +14,13 @@ postcard = { workspace = true, default-features = false, features = ["use-std"] 
 rand = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
-tokio = { workspace = true, features = ["full"] }
+tokio = { workspace = true, features = [
+    "sync",
+    "macros",
+    "io-util",
+    "rt",
+    "time",
+] }
 
 streambed = { path = "../streambed" }
 

--- a/streambed-kafka/Cargo.toml
+++ b/streambed-kafka/Cargo.toml
@@ -14,10 +14,16 @@ reqwest = { workspace = true, features = ["json"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 smol_str = { workspace = true, features = ["serde"] }
-tokio = { workspace = true, features = ["full"] }
+tokio = { workspace = true, features = [
+    "sync",
+    "macros",
+    "io-util",
+    "rt",
+    "time",
+] }
 tokio-stream = { workspace = true }
 
-streambed = { path = "../streambed" }
+streambed = { path = "../streambed", features = ["reqwest"] }
 
 [dev-dependencies]
 env_logger ={ workspace = true }

--- a/streambed-logged/Cargo.toml
+++ b/streambed-logged/Cargo.toml
@@ -16,7 +16,13 @@ postcard = { workspace = true, default-features = false, features = ["use-std", 
 serde = { workspace = true, features = ["derive"] }
 serde_with = { workspace = true, features = ["chrono_0_4"] }
 smol_str = { workspace = true, features = ["serde"] }
-tokio = { workspace = true, features = ["full"] }
+tokio = { workspace = true, features = [
+    "sync",
+    "macros",
+    "io-util",
+    "rt",
+    "time",
+] }
 tokio-stream = { workspace = true }
 tokio-util = { workspace = true, features = ["codec"] }
 

--- a/streambed-logged/src/compaction.rs
+++ b/streambed-logged/src/compaction.rs
@@ -504,7 +504,11 @@ where
                                         offset: record.offset,
                                     };
 
-                                    let Ok(buf) = postcard::to_stdvec_crc32(&storable_record, CRC.digest()) else {return Err(CompactionError::CannotSerialize)};
+                                    let Ok(buf) =
+                                        postcard::to_stdvec_crc32(&storable_record, CRC.digest())
+                                    else {
+                                        return Err(CompactionError::CannotSerialize);
+                                    };
                                     writer.write_all(&buf).map_err(CompactionError::IoError)?;
                                 }
                             }

--- a/streambed-logged/src/lib.rs
+++ b/streambed-logged/src/lib.rs
@@ -169,7 +169,9 @@ impl FileLog {
         CS: CompactionStrategy + Send + Sync + 'static,
     {
         let topic_file_op = {
-            let Ok(mut locked_topic_file_ops) = self.topic_file_ops.lock() else {return Err(CompactionRegistrationError)};
+            let Ok(mut locked_topic_file_ops) = self.topic_file_ops.lock() else {
+                return Err(CompactionRegistrationError);
+            };
             acquire_topic_file_ops(&self.root_path, &topic, &mut locked_topic_file_ops)
         };
 
@@ -237,7 +239,9 @@ impl FileLog {
 #[async_trait]
 impl CommitLog for FileLog {
     async fn offsets(&self, topic: Topic, _partition: Partition) -> Option<PartitionOffsets> {
-        let Ok(mut locked_topic_file_ops) = self.topic_file_ops.lock() else {return None};
+        let Ok(mut locked_topic_file_ops) = self.topic_file_ops.lock() else {
+            return None;
+        };
         let topic_file_op =
             acquire_topic_file_ops(&self.root_path, &topic, &mut locked_topic_file_ops);
         drop(locked_topic_file_ops);
@@ -255,7 +259,7 @@ impl CommitLog for FileLog {
     async fn produce(&self, record: ProducerRecord) -> ProduceReply {
         let topic_producer = {
             let Ok(mut locked_producer_map) = self.producer_txs.lock() else {
-                return Err(ProducerError::CannotProduce)
+                return Err(ProducerError::CannotProduce);
             };
             if let Some(topic_producer) = locked_producer_map.get(&record.topic) {
                 let producer_tx = topic_producer.clone();
@@ -267,7 +271,9 @@ impl CommitLog for FileLog {
                 locked_producer_map.insert(record.topic.clone(), producer_tx.clone());
                 drop(locked_producer_map); // drop early so we don't double-lock with the next thing
 
-                let Ok(mut locked_topic_file_ops) = self.topic_file_ops.lock() else {return Err(ProducerError::CannotProduce)};
+                let Ok(mut locked_topic_file_ops) = self.topic_file_ops.lock() else {
+                    return Err(ProducerError::CannotProduce);
+                };
                 let mut topic_file_op = acquire_topic_file_ops(
                     &self.root_path,
                     &record.topic,
@@ -474,7 +480,7 @@ impl CommitLog for FileLog {
 
                     let topic_file_op = {
                         let Ok(mut locked_topic_file_ops) = task_topic_file_ops.lock() else {
-                            break
+                            break;
                         };
                         let topic_file_op = acquire_topic_file_ops(
                             &task_root_path,
@@ -674,8 +680,8 @@ fn recover_active_file(
     let mut bytes_read = None;
     loop {
         let Ok(len) = read_buf(&mut topic_file, &mut buf) else {
-                break;
-            };
+            break;
+        };
 
         let before_decode_len = buf.len();
 

--- a/streambed-logged/src/topic_file_op.rs
+++ b/streambed-logged/src/topic_file_op.rs
@@ -66,7 +66,9 @@ impl TopicFileOp {
         // Ensure the active file is opened for appending first.
         let _ = self.with_active_file(open_options, write_buffer_size, |_| Ok(0))?;
 
-        let Ok(mut locked_write_handle) = self.write_handle.lock() else {return Err(TopicFileOpError::CannotLock)};
+        let Ok(mut locked_write_handle) = self.write_handle.lock() else {
+            return Err(TopicFileOpError::CannotLock);
+        };
         let r = if let Some(write_handle) = locked_write_handle.as_mut() {
             write_handle.get_ref().metadata().map(|m| m.len())
         } else {
@@ -76,7 +78,9 @@ impl TopicFileOp {
     }
 
     pub fn age_active_file(&mut self) -> Result<(), TopicFileOpError> {
-        let Ok(mut locked_write_handle) = self.write_handle.lock() else {return Err(TopicFileOpError::CannotLock)};
+        let Ok(mut locked_write_handle) = self.write_handle.lock() else {
+            return Err(TopicFileOpError::CannotLock);
+        };
         let present_path = self.root_path.join(self.topic.as_str());
         let ancient_history_path = present_path.with_extension(ANCIENT_HISTORY_FILE_EXTENSION);
         let history_path = present_path.with_extension(HISTORY_FILE_EXTENSION);
@@ -104,7 +108,9 @@ impl TopicFileOp {
     }
 
     pub fn flush_active_file(&self) -> Result<(), TopicFileOpError> {
-        let Ok(mut locked_write_handle) = self.write_handle.lock() else {return Err(TopicFileOpError::CannotLock)};
+        let Ok(mut locked_write_handle) = self.write_handle.lock() else {
+            return Err(TopicFileOpError::CannotLock);
+        };
         let r = if let Some(write_handle) = locked_write_handle.as_mut() {
             write_handle.flush()
         } else {
@@ -114,7 +120,9 @@ impl TopicFileOp {
     }
 
     pub fn open_active_file(&self, open_options: OpenOptions) -> Result<File, TopicFileOpError> {
-        let Ok(locked_write_handle) = self.write_handle.lock() else {return Err(TopicFileOpError::CannotLock)};
+        let Ok(locked_write_handle) = self.write_handle.lock() else {
+            return Err(TopicFileOpError::CannotLock);
+        };
         let present_path = self.root_path.join(self.topic.as_str());
         let r = open_options.open(present_path);
         drop(locked_write_handle);
@@ -126,7 +134,9 @@ impl TopicFileOp {
         open_options: OpenOptions,
         exclude_active_file: bool,
     ) -> Vec<io::Result<File>> {
-        let Ok(locked_write_handle) = self.write_handle.lock() else {return vec![]};
+        let Ok(locked_write_handle) = self.write_handle.lock() else {
+            return vec![];
+        };
 
         let mut files = Vec::with_capacity(3);
         let present_path = self.root_path.join(self.topic.as_str());
@@ -198,7 +208,9 @@ impl TopicFileOp {
     where
         F: FnOnce(&mut BufWriter<File>) -> Result<usize, TopicFileOpError>,
     {
-        let Ok(mut locked_write_handle) = self.write_handle.lock() else {return Err(TopicFileOpError::CannotLock)};
+        let Ok(mut locked_write_handle) = self.write_handle.lock() else {
+            return Err(TopicFileOpError::CannotLock);
+        };
         if let Some(write_handle) = locked_write_handle.as_mut() {
             f(write_handle).map(|size| (size, false))
         } else {

--- a/streambed-patterns/Cargo.toml
+++ b/streambed-patterns/Cargo.toml
@@ -5,4 +5,10 @@ edition = "2021"
 
 [dependencies]
 async-trait = { workspace = true }
-tokio = { workspace = true, features = ["full"] }
+tokio = { workspace = true, features = [
+    "sync",
+    "macros",
+    "io-util",
+    "rt",
+    "time",
+] }

--- a/streambed-storage/Cargo.toml
+++ b/streambed-storage/Cargo.toml
@@ -10,6 +10,12 @@ humantime = { workspace = true }
 rand = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
-tokio = { workspace = true, features = ["full"] }
+tokio = { workspace = true, features = [
+    "sync",
+    "macros",
+    "io-util",
+    "rt",
+    "time",
+] }
 
 streambed = { path = "../streambed" }

--- a/streambed-test/Cargo.toml
+++ b/streambed-test/Cargo.toml
@@ -6,4 +6,10 @@ edition = "2021"
 [dependencies]
 http = { workspace = true }
 hyper = { workspace = true, default-features = false, features = ["tcp", "stream", "http1", "http2", "client", "server", "runtime"] }
-tokio = { workspace = true, features = ["full"] }
+tokio = { workspace = true, features = [
+    "sync",
+    "macros",
+    "io-util",
+    "rt",
+    "time",
+] }

--- a/streambed-vault/Cargo.toml
+++ b/streambed-vault/Cargo.toml
@@ -12,9 +12,15 @@ log = { workspace = true }
 metrics = { workspace = true, default-features = false }
 reqwest = { workspace = true, features = ["json"] }
 serde = { workspace = true, features = ["derive"] }
-tokio = { workspace = true, features = ["full"] }
+tokio = { workspace = true, features = [
+    "sync",
+    "macros",
+    "io-util",
+    "rt",
+    "time",
+] }
 
-streambed = { path = "../streambed" }
+streambed = { path = "../streambed", features = ["reqwest"] }
 
 [dev-dependencies]
 env_logger = { workspace = true }

--- a/streambed/Cargo.toml
+++ b/streambed/Cargo.toml
@@ -14,13 +14,23 @@ hex = { workspace = true }
 hmac = { workspace = true }
 log = { workspace = true }
 rand = { workspace = true }
-reqwest = { workspace = true, features = ["json"] }
+reqwest = { workspace = true, optional = true }
 serde = { workspace = true, features = ["derive"] }
 serde_with = { workspace = true, features = ["base64"] }
 sha2 = { workspace = true }
 smol_str = { workspace = true, features = ["serde"] }
-tokio = { workspace = true, features = ["full"] }
+tokio = { workspace = true, features = [
+    "sync",
+    "macros",
+    "io-util",
+    "rt",
+    "time",
+] }
 tokio-stream = { workspace = true }
 
 [dev-dependencies]
 serde_json = { workspace = true }
+
+[features]
+# Use the reqwest library with its default features incl. TLS
+reqwest = ["dep:reqwest"]

--- a/streambed/src/lib.rs
+++ b/streambed/src/lib.rs
@@ -1,6 +1,5 @@
 #![doc = include_str!("../../README.md")]
 
-use std::error::Error;
 use std::io::{self, BufRead, BufReader, Read};
 use std::sync::Arc;
 use std::time::Duration;
@@ -8,6 +7,7 @@ use std::time::Duration;
 use crypto::SALT_SIZE;
 use log::{debug, info, warn};
 use rand::RngCore;
+#[cfg(feature = "reqwest")]
 use reqwest::Certificate;
 use serde::{Deserialize, Serialize};
 use tokio::sync::Notify;
@@ -30,7 +30,8 @@ pub fn read_line<R: Read>(reader: R) -> Result<String, io::Error> {
 }
 
 /// Read a pem file and return its corresponding Reqwest certificate.
-pub async fn read_pem<R: Read>(mut reader: R) -> Result<Certificate, Box<dyn Error>> {
+#[cfg(feature = "reqwest")]
+pub async fn read_pem<R: Read>(mut reader: R) -> Result<Certificate, Box<dyn std::error::Error>> {
     let mut buf = vec![];
     reader.read_to_end(&mut buf)?;
     Certificate::from_pem(&buf).map_err(|e| e.into())


### PR DESCRIPTION
Provides a more restrictive set of features for tokio aimed at WASM as the minimum. Also makes reqwest optional in the core crate so that we do not pull in TLS dependencies.