### PR TITLE
Correct some args

### DIFF
--- a/streambed-confidant/src/args.rs
+++ b/streambed-confidant/src/args.rs
@@ -6,7 +6,7 @@ use clap::Parser;
 
 #[derive(Parser, Debug)]
 pub struct SsArgs {
-    /// The max number of Vault Secret Store secrets to retain by our cache at any time.
+    /// The max number of Secret Store secrets to retain by our cache at any time.
     /// Least Recently Used (LRU) secrets will be evicted from our cache once this value
     /// is exceeded.
     #[clap(env, long, default_value_t = 10_000)]

--- a/streambed-logged/Cargo.toml
+++ b/streambed-logged/Cargo.toml
@@ -14,7 +14,6 @@ bytes = { workspace = true }
 chrono = { workspace = true }
 clap = { workspace = true, features = ["derive", "env"] }
 crc = { workspace = true }
-humantime = { workspace = true }
 log = { workspace = true }
 postcard = { workspace = true, default-features = false, features = ["use-std", "use-crc"] }
 serde = { workspace = true, features = ["derive"] }

--- a/streambed-logged/src/args.rs
+++ b/streambed-logged/src/args.rs
@@ -6,11 +6,6 @@ use clap::Parser;
 
 #[derive(Parser, Debug)]
 pub struct CommitLogArgs {
-    /// The amount of time to indicate that no more events are immediately
-    /// available from the Commit Log endpoint
-    #[clap(env, long, default_value = "100ms")]
-    pub cl_idle_timeout: humantime::Duration,
-
     /// A namespace to use when communicating with the Commit Log
     #[clap(env, long, default_value = "default")]
     pub cl_ns: String,


### PR DESCRIPTION
The idle timeout isn't actually used that often, so we can remove it as a regular argument. 