### PR TITLE
Improve subscription polling efficiency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ crc = "3.0.1"
 criterion = "0.4.0"
 env_logger = "0.10.0"
 exponential-backoff = "1.1.0"
-futures-util = "0.3"
+futures-util = { version = "0.3", default-features = false }
 hex = "0.4.3"
 http = "0.2.8"
 hmac = "0.12.1"

--- a/streambed-codec/Cargo.toml
+++ b/streambed-codec/Cargo.toml
@@ -13,7 +13,7 @@ streambed.workspace = true
 rand.workspace = true
 ciborium.workspace = true
 serde.workspace = true
-futures-util = { workspace = true, default-features = false }
+futures-util.workspace = true
 async-stream.workspace = true
 
 

--- a/streambed-logged/src/compaction.rs
+++ b/streambed-logged/src/compaction.rs
@@ -875,7 +875,7 @@ mod tests {
                 TemperatureSensorEventKey::NameChanged(id) => (1u64, id),
                 TemperatureSensorEventKey::TemperatureSensed(id) => (2u64, id),
             };
-            event_type << EVENT_TYPE_BIT_SHIFT | (id as u64)
+            (event_type << EVENT_TYPE_BIT_SHIFT) | (id as u64)
         }
     }
 


### PR DESCRIPTION
Subscriptions would wake up every 100ms or so and then read through the log to publish anything written since the last offset. This could cause a lot of record reading and deserialisation without yielding anything new. Profiling of another project using streambed-logged highlighted this as a major area of CPU consumption.

The change here is to quickly check if the last log file has been modified since we last looked. If it hasn't, go to sleep again. This saves a large amount of processing.

Profiled the before and after to confirm the change. No noticable CPU usage after the change.